### PR TITLE
구독 목록 간헐적으로 불러오지 못하는 문제 해결

### DIFF
--- a/@util/functions/cryptoValue.ts
+++ b/@util/functions/cryptoValue.ts
@@ -1,0 +1,25 @@
+import crypto from 'crypto';
+
+// 환경 변수에서 키와 IV 가져오기
+const ENCRYPTION_KEY = process.env.ENCRYPTION_KEY || ''; // 32자
+const ENCRYPTION_IV = process.env.ENCRYPTION_IV || ''; // 16자
+
+if (ENCRYPTION_KEY.length !== 32 || ENCRYPTION_IV.length !== 16) {
+    throw new Error("Invalid ENCRYPTION_KEY or ENCRYPTION_IV length. Key must be 32 chars, IV must be 16 chars.");
+}
+
+/** 암호화 함수  */
+export const encrypt = (text: string): string => {
+    const cipher = crypto.createCipheriv('aes-256-cbc', Buffer.from(ENCRYPTION_KEY), Buffer.from(ENCRYPTION_IV));
+    let encrypted = cipher.update(text, 'utf8', 'base64');
+    encrypted += cipher.final('base64');
+    return encrypted;
+};
+
+/** 복호화 함수 */
+export const decrypt = (encryptedText: string): string => {
+    const decipher = crypto.createDecipheriv('aes-256-cbc', Buffer.from(ENCRYPTION_KEY), Buffer.from(ENCRYPTION_IV));
+    let decrypted = decipher.update(encryptedText, 'base64', 'utf8');
+    decrypted += decipher.final('utf8');
+    return decrypted;
+};

--- a/@util/functions/fetch/fetchGetDBUserData.ts
+++ b/@util/functions/fetch/fetchGetDBUserData.ts
@@ -1,4 +1,4 @@
-import { DBUserdataType } from "@/types/userdata";
+import { ClientUserdataType } from "@/types/userdata";
 import axios from "axios";
 import { Session } from "next-auth";
 
@@ -20,7 +20,7 @@ export default async function fetchGetDBUserData(
             `/api/post/database/user/data`, session
         );
 
-        const userdata : DBUserdataType = dbUserdataResult.data.userdata
+        const userdata : ClientUserdataType = dbUserdataResult.data.userdata
 
         return userdata;
     }catch(error){

--- a/@util/functions/fetch/fetchRefreshAccessToken.ts
+++ b/@util/functions/fetch/fetchRefreshAccessToken.ts
@@ -1,0 +1,81 @@
+import axios from "axios";
+
+// web url
+const nextAuthUrl = process.env.NEXTAUTH_URL;
+
+if (!nextAuthUrl) {
+    throw new Error("NEXTAUTH_URL is not defined in the environment variables.");
+}
+
+type TokenInfo = {
+    accessToken: string | null;
+    refreshToken: string | null;
+    tokenCreatedAt: number | null;
+    expiresIn: number;
+};
+
+// token info
+export let tokenInfo: TokenInfo = {
+    accessToken: null,
+    refreshToken: null,
+    tokenCreatedAt: null,
+    expiresIn: 3600,
+};
+
+// 동시 갱신 방지 플래그와 큐
+let isRefreshing = false;
+let refreshQueue: (() => void)[] = [];
+
+/** Access Token 만료 여부 확인 */
+export const isTokenExpired = (): boolean => {
+    const currentTime = Math.floor(Date.now() / 1000);
+    if (!tokenInfo.tokenCreatedAt || !tokenInfo.expiresIn) {
+        console.warn("Token expiration check failed: tokenCreatedAt or expiresIn is missing.");
+        return true; // 유효성 확인 실패 시 만료로 간주
+    }
+    return currentTime >= tokenInfo.tokenCreatedAt + tokenInfo.expiresIn;
+};
+
+/** Access Token 갱신 */
+export const refreshAccessToken = async (): Promise<void> => {
+    if (!tokenInfo.refreshToken) {
+        throw new Error("Refresh Token is missing. Please log in again.");
+    }
+
+    if (isRefreshing) {
+        return new Promise<void>((resolve) => {
+            refreshQueue.push(resolve);
+        });
+    }
+
+    isRefreshing = true;
+
+    try {
+        const response = await axios.post<{ accessToken: string; expiresIn: number }>(
+            `${nextAuthUrl}/api/auth/refresh-token`,
+            { refreshToken: tokenInfo.refreshToken },
+            {
+                headers: { "Content-Type": "application/json" },
+            }
+        );
+
+        tokenInfo.accessToken = response.data.accessToken;
+        tokenInfo.tokenCreatedAt = Math.floor(Date.now() / 1000); // 현재 시간 기준
+        tokenInfo.expiresIn = response.data.expiresIn; // Refresh API 응답 값 사용
+
+        refreshQueue.forEach((resolve) => resolve());
+        refreshQueue = [];
+    }  catch (error: any) {
+        refreshQueue.forEach((resolve) => resolve());
+        refreshQueue = [];
+
+        console.error("Error refreshing access token:", error.response?.data || error.message);
+
+        if (error.response?.status === 401) {
+            throw new Error("Unauthorized: Refresh Token is invalid or expired.");
+        }
+        throw new Error("Failed to refresh access token.");
+    } finally {
+        isRefreshing = false;
+    }
+};

--- a/@util/functions/fetch/fetchSubscribedYoutuberData.ts
+++ b/@util/functions/fetch/fetchSubscribedYoutuberData.ts
@@ -7,8 +7,9 @@ import axios from "axios";
  */
 export default async function fetchSubscribedYoutuberData(){
     try{
-        let resultGetSubscription = await axios.get('/api/get/subscribe');
-        const subscription : SubScibedYoutuberType[] = resultGetSubscription.data 
+        const resultGetSubscription = await axios.get('/api/get/subscribe');
+        const subscription : SubScibedYoutuberType[] = resultGetSubscription.data;
+
         return subscription;
     }catch(error){
         // error가 AxiosError인지 확인

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -76,6 +76,7 @@ export default function RootLayout({
                 <link rel="apple-touch-startup-image" media="screen and (device-width: 744px) and (device-height: 1133px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)" href="splash_screens/8.3__iPad_Mini_portrait.png"/>
                 <meta name="apple-mobile-web-app-capable" content="yes" />
                 <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+                <meta name="mobile-web-app-capable" content="yes" />
                 <meta name="google-site-verification" content="JBdVYDDSjbAEZ4ybo1VQ-ZfeHeIovnIxKB4gmNeN9YQ"/>
             </head>
             <body className={inter.className}>

--- a/app/my-page/Main/MypageHubcontainer.tsx
+++ b/app/my-page/Main/MypageHubcontainer.tsx
@@ -48,8 +48,8 @@ export default function MyPageHub() {
 
     const Heartnumber = [data.length, userdata?.youtuberHeart.length ?? 0,  userdata?.videoHeart.length ?? 0];
 
-    if (!userdata || userdata.youtuberHeart.length === 0){
-        return <ErrorContainer errorMessage="구독한 유튜버가 없습니다." />;
+    if (!userdata){
+        return <ErrorContainer errorMessage="회원 정보를 확인할 수 없습니다." />;
     }
 
     return (

--- a/app/store.ts
+++ b/app/store.ts
@@ -1,4 +1,4 @@
-import { DBUserdataType, UserHeartedType } from "@/types/userdata";
+import { ClientUserdataType, UserHeartedType } from "@/types/userdata";
 import { RefObject } from "react";
 import { create } from "zustand"
 
@@ -82,8 +82,8 @@ export const useVideoRenderStateStore = create<VideoRenderState>((set) => ({
 
 
 interface DBUserStore {
-    userdata: DBUserdataType | undefined; // 초기값으로 undefined
-    setUserdata: (data: DBUserdataType) => void; // userdata 설정
+    userdata: ClientUserdataType | undefined; // 초기값으로 undefined
+    setUserdata: (data: ClientUserdataType) => void; // userdata 설정
     clearUserdata: () => void; // userdata 초기화
     addHeart: (type: "videoHeart" | "youtuberHeart", heartData: UserHeartedType) => void; // heart 추가 함수
     removeHeart: (type: "videoHeart" | "youtuberHeart", id: string) => void; // heart 삭제 함수

--- a/app/video/[id]/components/Comment/CommentCardContainer.tsx
+++ b/app/video/[id]/components/Comment/CommentCardContainer.tsx
@@ -44,7 +44,7 @@ export function CommentCardContainer(
         <div className="card-container p-2 mb-2">
             <div className="row row-center w-100" style={{ margin: 'auto' }}>
                 <div className="col-12 col-sm-2 col-lg-1">
-                    <div style={{margin : 'auto', maxWidth : 50}}>
+                    <div style={{marginRight : 'auto', maxWidth : 50}}>
                         <Image
                             src={commentData.autohorProfileImageUrl}
                             alt={commentData.authorDisplayName}
@@ -65,14 +65,14 @@ export function CommentCardContainer(
                             <p className="m-sm-0 fw-bold d-sm-block d-none">{commentData.authorDisplayName}</p>
                             {
                                 textArr.map((line, index) => (
-                                    <p className="m-sm-0" key={index}>
+                                    <p className="m-0" key={index}>
                                         {convertTextWithTimestamps(line)}
                                     </p>
                                 ))
                             }
                         </div>
                         <div className="col-12 col-lg-4 px-sm-2 px-0 text-sm-start text-end">
-                            <p className="m-0">{dateToString(commentData.publishedAt)}</p>
+                            <p className="m-0 mt-3 mt-sm-0">{dateToString(commentData.publishedAt)}</p>
                             <p className="m-0">
                                 <span style={{color : '#ff0000'}}>
                                     <FontAwesomeIcon icon={faHeart} />

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -1,46 +1,43 @@
-import NextAuth from 'next-auth';
-import { JWT } from 'next-auth/jwt';
-import GoogleProvider from 'next-auth/providers/google';
+import NextAuth from "next-auth";
+import { JWT } from "next-auth/jwt";
+import GoogleProvider from "next-auth/providers/google";
 
 export const authOptions = {
-    // Configure one or more authentication providers
     providers: [
         GoogleProvider({
             clientId: process.env.GOOGLE_CLIENT_ID || '',
             clientSecret: process.env.GOOGLE_CLIENT_SECRET || '',
             authorization: {
                 params: {
-                    // YouTube 구독 목록 읽기 권한
-                    scope: "openid email profile https://www.googleapis.com/auth/youtube.readonly",  
+                    scope: "openid email profile https://www.googleapis.com/auth/youtube.readonly",
                     redirect_uri: `${process.env.NEXTAUTH_URL}/api/auth/callback/google`,
+                    access_type: "offline", // Refresh Token 요청
+                    // prompt: "consent", // 항상 새 Refresh Token 요청
                 }
             }
         })
-        // ...add more providers here
     ],
-    pages : {
+    pages: {
         signIn: "/auth/sign-in",
     },
-    secret : process.env.NEXTAUTH_SECRET,
+    secret: process.env.NEXTAUTH_SECRET,
     callbacks: {
-        async redirect({ baseUrl } : { baseUrl: string }) {
-            // /main 루트로 리디렉트
-            return `${baseUrl}/main`;
+        async redirect({ baseUrl }: { baseUrl: string }) {
+            return `${baseUrl}/main`; // 로그인 후 /main으로 리디렉션
         },
-        // idToken = 사용자의 신원 검증에 사용하는 jwt token
-        // 당장은 필요없어서 주석처리
-        async jwt({ token, account } : { token: JWT, account?: any }) {
+        async jwt({ token, account }: { token: JWT; account?: any }) {
             if (account) {
                 token.accessToken = account.access_token;
-                // token.idToken = account.id_token; // id_token 추가
+                token.refreshToken = account.refresh_token || token.refreshToken; // 기존 값 유지
             }
             return token;
         },
-        async session({ session, token } : { session: any, token: JWT }) {
+        async session({ session, token }: { session: any; token: JWT }) {
             session.accessToken = token.accessToken;
-            // session.idToken = token.idToken; // id_token 추가
+            session.refreshToken = token.refreshToken;
             return session;
         },
     },
 };
+
 export default NextAuth(authOptions);

--- a/pages/api/auth/refresh-token.ts
+++ b/pages/api/auth/refresh-token.ts
@@ -1,0 +1,52 @@
+import axios from "axios";
+import { NextApiRequest, NextApiResponse } from "next";
+
+const clientId = process.env.GOOGLE_CLIENT_ID;
+const clientSecret = process.env.GOOGLE_CLIENT_SECRET;
+
+export default async function handler(
+    req: NextApiRequest, res: NextApiResponse
+) {
+    if (req.method !== "POST") {
+        return res.status(405).json({ message: "Method not allowed" });
+    }
+
+    if(!clientId){
+        return res.status(500).json({ message: "Invalid client id"});
+    }
+
+    if(!clientSecret){
+        return res.status(500).json({ message : "Invalid client secret" });
+    }
+
+    const { refreshToken } = req.body;
+
+    if (!refreshToken) {
+        return res.status(400).json({ message: "Refresh token is required" });
+    }
+
+    try {
+        const response = await axios.post(
+            "https://oauth2.googleapis.com/token",
+            new URLSearchParams({
+                client_id: clientId,
+                client_secret: clientSecret,
+                refresh_token: refreshToken,
+                grant_type: "refresh_token",
+            }).toString(),
+            {
+                headers: {
+                    "Content-Type": "application/x-www-form-urlencoded",
+                },
+            }
+        );
+
+        res.status(200).json({
+            accessToken: response.data.access_token,
+            expiresIn: response.data.expires_in,
+        });
+    } catch (error) {
+        console.error("Failed to refresh token:", error);
+        res.status(500).json({ message: "Failed to refresh access token" });
+    }
+}

--- a/pages/api/get/database/user/data.ts
+++ b/pages/api/get/database/user/data.ts
@@ -1,4 +1,5 @@
 import { connectDB } from "@/@util/database";
+import { DBUserdataType } from "@/types/userdata";
 import { Db } from "mongodb";
 import { NextApiRequest, NextApiResponse } from "next";
 
@@ -28,9 +29,15 @@ export default async function handler(
 
     try {
         // 이메일로 기존 유저 데이터 검색
-        const dbUserData = await db.collection('userdata').findOne({ email: userEmail });
+        const dbUserData = await db.collection<DBUserdataType>('userdata').findOne({ email: userEmail });
 
-        return res.status(200).json({ userdata: dbUserData });
+        if (!dbUserData) {
+            return res.status(404).json({ message: "User data not found" });
+        }
+
+        const { refreshToken, ...clientUserdata } = dbUserData;
+
+        return res.status(200).json({ userdata: clientUserdata });
     } catch (dbError) {
         return res.status(500).json({ message: "Database operation failed", error: dbError });
     }

--- a/pages/api/post/database/user/data.ts
+++ b/pages/api/post/database/user/data.ts
@@ -3,8 +3,10 @@ import { connectDB } from "@/@util/database";
 import { DBUserdataType } from "@/types/userdata";
 import { Db, ObjectId } from "mongodb";
 import { NextApiRequest, NextApiResponse } from "next";
-import { Session } from "next-auth";
+import { getServerSession, Session } from "next-auth";
 import { getClientIp, rateLimiter } from "@/@util/functions/rateLimit";
+import { authOptions } from "@/pages/api/auth/[...nextauth]";
+import { encrypt } from "@/@util/functions/cryptoValue";
 
 interface UserdataType {
     name?: string | null;
@@ -31,14 +33,36 @@ export default async function handler(
         return res.status(405).json({ message: "Method Not Allowed" });
     }
 
-    const session: Session = req.body;
-    const userdata = session?.user;
+    const session: Session | null = await getServerSession(req, res, authOptions);
+
+    if (!session) {
+        return res.status(405).json({ message: "User Not Defined." });
+    }
+
+    const userdata = session.user;
 
     if (!userdata) {
-        return res.status(400).json({ message: "user data required" });
+        return res.status(400).json({ message: "User Data required." });
+    }
+
+    if (!userdata.email) {
+        return res.status(400).json({ message: "User Email required." });
+    }
+
+    let refreshToken = session.refreshToken;
+
+    // refresh token 이 할당되지 않은 경우
+    let encryptedToken: string | null = null;
+
+    // refreshToken이 없는 경우 처리
+    if (!refreshToken) {
+        console.warn("Refresh token is undefined. Skipping encryption.");
+    } else {
+        encryptedToken = encrypt(refreshToken);
     }
 
     let db: Db;
+
     try {
         db = (await connectDB).db('youtube');
     } catch (error) {
@@ -49,30 +73,61 @@ export default async function handler(
         return res.status(403).json({ message: "user email required" });
     }
 
+    const userEmail = userdata.email;
+
     try {
-        const dbUserData = await db.collection('userdata')
-        .findOne({ email: userdata.email });
+        const dbUserData = await db.collection<DBUserdataType>('userdata')
+            .findOne({ email: userEmail });
 
         // 새로운 유저 데이터 준비
-        const newUserData : DBUserdataType = {
+        const newUserData: DBUserdataType = {
             _id: new ObjectId(),
             name: userdata.name || generateRandomName(6),
-            email: userdata.email,
+            email: userEmail,
             image: userdata.image || null,
+            refreshToken: encryptedToken,
             youtuberHeart: [],
             videoHeart: [],
         };
 
         if (!dbUserData) {
+            // 유저 데이터가 존재하지 않으면 새로 삽입
             try {
                 await db.collection('userdata').insertOne(newUserData);
-                
                 return res.status(201).json({ userdata: newUserData });
             } catch (insertError) {
-                return res.status(500).json({ message: "Failed to create new user data", error: insertError });
+                return res.status(500).json({
+                    message: "Failed to create new user data",
+                    error: insertError,
+                });
             }
         } else {
-            return res.status(200).json({ userdata : dbUserData });
+            // 유저 데이터가 존재하는 경우
+            if (!dbUserData.refreshToken && encryptedToken) {
+                // 기존 refreshToken이 null이고, 새 encryptedToken이 존재하면 업데이트
+                try {
+                    await db.collection('userdata').updateOne(
+                        { email: userEmail },
+                        { $set: { refreshToken: encryptedToken } }
+                    );
+                    // 업데이트된 데이터를 반환
+                    const updatedUserData = await db
+                        .collection<DBUserdataType>('userdata')
+                        .findOne({ email: userEmail });
+                    return res.status(200).json({
+                        message: "User refresh token updated",
+                        userdata: updatedUserData,
+                    });
+                } catch (updateError) {
+                    return res.status(500).json({
+                        message: "Failed to update user refresh token",
+                        error: updateError,
+                    });
+                }
+            }
+
+            // refreshToken 업데이트 필요 없는 경우 기존 데이터 반환
+            return res.status(200).json({ userdata: dbUserData });
         }
     } catch (dbError) {
         return res.status(500).json({ message: "Database operation failed", error: dbError });

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -4,6 +4,6 @@ import NextAuth from 'next-auth';
 declare module 'next-auth' {
   interface Session {
     accessToken?: string;
-    idToken?: string; // 필요 없다면 제거해도 됨
+    refreshToken?: string;
   }
 }

--- a/types/userdata.ts
+++ b/types/userdata.ts
@@ -10,6 +10,16 @@ export interface DBUserdataType {
     videoHeart: UserHeartedType[];
 }
 
+export interface ClientUserdataType {
+    _id: ObjectId;
+    name: string;
+    email: string;
+    image: string | null;
+    youtuberHeart: UserHeartedType[];
+    videoHeart: UserHeartedType[];
+}
+
+
 export interface UserHeartedType {
     id : string;
     name : string;

--- a/types/userdata.ts
+++ b/types/userdata.ts
@@ -5,6 +5,7 @@ export interface DBUserdataType {
     name: string;
     email: string;
     image: string | null;
+    refreshToken : string | null;
     youtuberHeart: UserHeartedType[];
     videoHeart: UserHeartedType[];
 }


### PR DESCRIPTION
## 한줄요약 : JWT refreshToken의 문제였음.

#### accesToken, expires, refreshToken
next auth jwt 설정을 통해 accessToken, refreshToken, expires를 얻을 수 있는데 각각 통행증, 신분증, 통행증 만료기간이라고 비유하겠음.
프로젝트에선 accessToken을 통해 구독 목록을 불러옴. 즉, 인증된 통행증을 통해서만 구독 목록이 확인 가능함.
그런데 expires, 통행증 만료 기간이 종료되면 통행증이 인증되지 못한 상태로 바뀜. 이 경우엔 구독 목록 확인이 불가능해짐.
그래서 필요한게 refreshToken, 신분증을 통해 새롭게 통행증을 발급 받아야함. 앞서 오류가 발생했던 이유는 통행증이 만료되었음에도 재발급을 받지 않았기 때문. 그래서 재로그인을 통해 다시 통행증을 발급 받아야만 구독 목록 확인이 가능해진것.

#### refreshToken
신분증이라 비유한 이유는 refreshToken은 재발급이 어렵기 때문임. 웹에 최초 1회 로그인할때 refreshToken이 부여되고, 이는 db 혹은 쿠키에 보관되어야 함. 또한 보안의 위험성이 있기에 AES로 암호화가 필요함. 이 프로젝트에서는 crypto 라이브러리로 암호화 한 후 db에 저장하는 방식을 채택함. 사용자가 최초 1회 로그인할때 db에 사용자 정보와 함께 암호화된 refresh Token을 저장하고 accessToken이 만료될 때마다 이를 불러와서 사용함.